### PR TITLE
Implementacja FCM

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,9 +6,19 @@ add_executable(ntwi
 )
 
 add_compile_definitions(ntwi
-	"DEBUG_LOGGING"
+	$<$<CONFIG:Debug>:DEBUG_LOGGING>
 )
 
 set_target_properties(ntwi PROPERTIES
 	CXX_STANDARD 20
 )
+
+if ((CMAKE_CXX_COMPILER_ID STREQUAL "Clang") OR (CMAKE_CXX_COMPILER_ID STREQUAL "GNU"))
+	target_compile_options(ntwi PRIVATE
+		-Wall
+		-Wextra
+		-Wno-unused-parameter
+		$<$<CONFIG:Release>:-ffast-math>
+		$<$<CONFIG:Release>:-march=native>
+	)
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,3 +9,6 @@ add_compile_definitions(ntwi
 	"DEBUG_LOGGING"
 )
 
+set_target_properties(ntwi PROPERTIES
+	CXX_STANDARD 20
+)

--- a/src/fcm.hpp
+++ b/src/fcm.hpp
@@ -106,7 +106,22 @@ void granulate_fcm(
 			}
 		}
 		
-		// Update partition
+		// Update partition matrix
+		for (size_t cluster_id = 0; cluster_id < num_clusters; cluster_id++)
+		{
+			for (size_t record_id = begin_id; record_id < end_id; record_id++)
+			{
+				T sum = 0;
+				for (size_t i = 0; i < num_clusters; i++)
+					sum += std::pow(
+						cluster_distance(cluster_id, record_id - begin_id) / cluster_distance(i, record_id - begin_id),
+						1 / (exponent - 1)
+					);
+				
+				membership_value(cluster_id, record_id - begin_id) = 1 / sum;
+			}
+		}
+		
 		normalize_partition_matrix();
 	}
 	

--- a/src/fcm.hpp
+++ b/src/fcm.hpp
@@ -1,0 +1,122 @@
+#pragma once
+#include "dataset.hpp"
+#include <optional>
+#include <span>
+#include <random>
+
+template <typename T, typename RNG>
+void granulate_fcm(
+	const sparse_dataset<T> &input,
+	sparse_dataset<T> &output,
+	const size_t begin_id,
+	const size_t end_id,
+	const std::span<size_t> &attrib_ids,
+	const size_t num_clusters,
+	const T exponent,
+	const size_t num_iterations,
+	RNG &rng)
+{
+	const auto num_records = end_id - begin_id;
+	const auto num_attribs = attrib_ids.size();
+	
+	assert(input.num_attributes() == output.num_attributes());
+	assert(num_attribs);
+	assert(num_records);
+	assert(num_clusters);
+	assert(exponent > 1);
+	
+	std::vector<T> partition_matrix(num_clusters * num_records);
+	auto membership_value = [&](size_t cluster_id, size_t record_id) -> T& {
+		assert(cluster_id < num_clusters);
+		assert(record_id < num_records);
+		return partition_matrix.at(cluster_id * num_records + record_id);
+	};
+	
+	std::vector<T> cluster_centers(num_clusters * num_attribs);
+	auto cluster_center_attrib = [&](size_t cluster_id, size_t attrib) -> T& {
+		assert(cluster_id < num_clusters);
+		assert(attrib < num_attribs);
+		return cluster_centers.at(cluster_id * num_attribs + attrib);
+	};
+	
+	// Note: these are actually distances squared
+	std::vector<T> cluster_distances(num_clusters * num_records);
+	auto cluster_distance = [&](size_t cluster_id, size_t record_id) -> T& {
+		assert(cluster_id < num_clusters);
+		assert(record_id < num_records);
+		return cluster_distances.at(cluster_id * num_records + record_id);
+	};
+	
+	auto normalize_partition_matrix = [&]() {
+		for (size_t record_id = begin_id; record_id < end_id; record_id++)
+		{
+			T membership_sum = 0;
+			
+			for (size_t cluster_id = 0; cluster_id < num_clusters; cluster_id++)
+				membership_sum += membership_value(cluster_id, record_id);
+			
+			assert(membership_sum > 0);
+			
+			for (size_t cluster_id = 0; cluster_id < num_clusters; cluster_id++)
+				membership_value(cluster_id, record_id) /= membership_sum;
+		}
+	};
+	
+	
+	// Randomize & normalize partition matrix
+	std::uniform_real_distribution<T> dist{0, 1};
+	for (auto &u : partition_matrix)
+		u = dist(rng);
+	
+	normalize_partition_matrix();
+	
+	for (size_t iter = 0; iter < num_iterations; iter++)
+	{
+		// Update cluster centers
+		for (size_t cluster_id = 0; cluster_id < num_clusters; cluster_id++)
+		{
+			for (size_t attrib = 0; attrib < num_attribs; attrib++)
+				cluster_center_attrib(cluster_id, attrib) = 0;
+			
+			T factor_sum = 0;
+			for (size_t record_id = begin_id; record_id < end_id; record_id++)
+			{
+				auto factor = std::pow(membership_value(cluster_id, record_id), exponent);
+				factor_sum += factor;
+				
+				for (size_t attrib = 0; attrib < num_attribs; attrib++)
+					cluster_center_attrib(cluster_id, attrib) += factor * *input.get(record_id, attrib_ids.at(attrib));
+			}
+			
+			for (size_t attrib = 0; attrib < num_attribs; attrib++)
+				cluster_center_attrib(cluster_id, attrib) /= factor_sum;
+		}
+		
+		// Update record/cluster distances
+		for (size_t cluster_id = 0; cluster_id < num_clusters; cluster_id++)
+		{
+			for (size_t record_id = begin_id; record_id < end_id; record_id++)
+			{
+				cluster_distance(cluster_id, record_id) = 0;
+				for (size_t attrib = 0; attrib < num_attribs; attrib++)
+				{
+					auto diff = *input.get(record_id, attrib_ids.at(attrib)) - cluster_center_attrib(cluster_id, attrib);
+					cluster_distance(cluster_id, record_id) += diff * diff;
+				}
+			}
+		}
+		
+		// Update partition
+		normalize_partition_matrix();
+	}
+	
+	for (size_t cluster_id = 0; cluster_id < num_clusters; cluster_id++)
+	{
+		std::vector<T> granule_attribs(output.num_attributes(), NAN);
+		
+		for (size_t attrib = 0; attrib < num_attribs; attrib++)
+			granule_attribs.at(attrib_ids.at(attrib)) = cluster_center_attrib(cluster_id, attrib);
+		
+		output.insert(input.get_source(begin_id), granule_attribs);
+	}	
+}

--- a/src/fcm.hpp
+++ b/src/fcm.hpp
@@ -53,12 +53,12 @@ void granulate_fcm(
 			T membership_sum = 0;
 			
 			for (size_t cluster_id = 0; cluster_id < num_clusters; cluster_id++)
-				membership_sum += membership_value(cluster_id, record_id);
+				membership_sum += membership_value(cluster_id, record_id - begin_id);
 			
 			assert(membership_sum > 0);
 			
 			for (size_t cluster_id = 0; cluster_id < num_clusters; cluster_id++)
-				membership_value(cluster_id, record_id) /= membership_sum;
+				membership_value(cluster_id, record_id - begin_id) /= membership_sum;
 		}
 	};
 	
@@ -81,7 +81,7 @@ void granulate_fcm(
 			T factor_sum = 0;
 			for (size_t record_id = begin_id; record_id < end_id; record_id++)
 			{
-				auto factor = std::pow(membership_value(cluster_id, record_id), exponent);
+				auto factor = std::pow(membership_value(cluster_id, record_id - begin_id), exponent);
 				factor_sum += factor;
 				
 				for (size_t attrib = 0; attrib < num_attribs; attrib++)
@@ -97,11 +97,11 @@ void granulate_fcm(
 		{
 			for (size_t record_id = begin_id; record_id < end_id; record_id++)
 			{
-				cluster_distance(cluster_id, record_id) = 0;
+				cluster_distance(cluster_id, record_id - begin_id) = 0;
 				for (size_t attrib = 0; attrib < num_attribs; attrib++)
 				{
 					auto diff = *input.get(record_id, attrib_ids.at(attrib)) - cluster_center_attrib(cluster_id, attrib);
-					cluster_distance(cluster_id, record_id) += diff * diff;
+					cluster_distance(cluster_id, record_id - begin_id) += diff * diff;
 				}
 			}
 		}

--- a/src/ntwi.cpp
+++ b/src/ntwi.cpp
@@ -1,10 +1,32 @@
 #include "dataset.hpp"
+#include "fcm.hpp"
+#include <random>
 
 int main(int argc, char *argv[])
 {
 	assert(argc > 1);
 	sparse_dataset<float> dataset{argv[1]};
 	std::cout << dataset << "\n";
+	
+	
+	std::mt19937 rng{1}; // TODO seed rng
+	sparse_dataset<float> granules{dataset.num_attributes()};
+	
+
+	size_t attribs[2] = {1, 2};
+	granulate_fcm(
+		dataset,
+		granules,
+		0,
+		20, 
+		attribs,
+		3, 
+		2.f, 
+		10,
+		rng
+	);
+	
+	std::cout << granules << std::endl;
 	
 	return 0;
 }

--- a/src/ntwi.cpp
+++ b/src/ntwi.cpp
@@ -12,19 +12,27 @@ int main(int argc, char *argv[])
 	std::mt19937 rng{1}; // TODO seed rng
 	sparse_dataset<float> granules{dataset.num_attributes()};
 	
-
-	size_t attribs[2] = {1, 2};
-	granulate_fcm(
-		dataset,
-		granules,
-		0,
-		20, 
-		attribs,
-		3, 
-		2.f, 
-		10,
-		rng
-	);
+	for (size_t source = 0; source < dataset.num_sources(); source++)
+	{
+		auto [record_begin, record_end] = dataset.get_source_data_range(source);
+		auto attribs = dataset.get_record_attribute_ids(record_begin);
+		
+		float fuzzy_exponent = 2.f;
+		int iterations = 10;
+		int num_clusters = 3;
+		
+		granulate_fcm(
+			dataset,
+			granules,
+			record_begin,
+			record_end, 
+			attribs,
+			num_clusters, 
+			fuzzy_exponent, 
+			iterations,
+			rng
+		);
+	}
 	
 	std::cout << granules << std::endl;
 	


### PR DESCRIPTION
Implementacja FCM operująca na `sparse_dataset`. 

Na oko granulacja wygląda w miarę sensownie (czerwone punkty to środki granul):
![image](https://github.com/Mich121/NTWI_Project_LostDataEstimator/assets/6173262/7242abcc-a965-4ead-ad7e-72994f6580cf)

Teraz trzeba zaimplementować kNN, żeby uzupełnić brakujące dane (do tego trzeba będzie dodać nowy akcesor w tej klasie).